### PR TITLE
Re-add flake8-aaa

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Table of Contents
 - [flake8-assertive](https://github.com/jparise/flake8-assertive) - Flake8 unittest assert method checker
 - [flake8-mock](https://github.com/aleGpereira/flake8-mock) - Provides checking mock non-existent methods
 - [flake8-pytest](https://github.com/vikingco/flake8-pytest) - Enforces to use `pytest`-style assertions
+- [flake8-aaa](https://github.com/jamescooke/flake8-aaa) - Lints tests against the Arrange Act Assert pattern
 
 
 ## Security


### PR DESCRIPTION
This was originally added in https://github.com/DmytroLitvinov/awesome-flake8-extensions/pull/3 . 

But since then, this commit removed a bunch of plugins: https://github.com/DmytroLitvinov/awesome-flake8-extensions/commit/0d65f440fd15ec9d0881f45fb5508855f0d01630

I've checked over that merge commit - all the other deleted plugins are now in the list :+1: Just Flake8-AAA was missed.