### PR TITLE
Add flake8-absolute-import to 'imports' section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Inspired after reading a [post](https://julien.danjou.info/the-best-flake8-exten
 - [flake8-import-style](https://github.com/sfstpala/flake8-import-style) - Plugin to ensure explicit module imports.
 - [flake8-isort](https://github.com/gforcada/flake8-isort) - Plugin that integrates [isort](https://pypi.org/project/isort/).
 - [flake8-tidy-imports](https://github.com/adamchainz/flake8-tidy-imports) - Extension that helps you write tidier imports.
-- [flake8-absolute-import](https://github.com/bskinn/flake8-absolute-import) - Plugin to prohibit relative imports.
+- [flake8-absolute-import](https://github.com/bskinn/flake8-absolute-import) - Plugin to require absolute imports.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Inspired after reading a [post](https://julien.danjou.info/the-best-flake8-exten
 - [flake8-import-style](https://github.com/sfstpala/flake8-import-style) - Plugin to ensure explicit module imports.
 - [flake8-isort](https://github.com/gforcada/flake8-isort) - Plugin that integrates [isort](https://pypi.org/project/isort/).
 - [flake8-tidy-imports](https://github.com/adamchainz/flake8-tidy-imports) - Extension that helps you write tidier imports.
+- [flake8-absolute-import](https://github.com/bskinn/flake8-absolute-import) - Plugin to prohibit relative imports.
 
 ## Security
 


### PR DESCRIPTION
The [plugin](https://github.com/bskinn/flake8-absolute-import) is straightforwardly related to flake8 linting of imports, and has seen steady PyPI downloads (couple dozen per day) for about [three months now](https://pypistats.org/packages/flake8-absolute-import).

While there's still considerable debate about preferences on absolute vs relative imports, for those projects that have decided to hold strictly to absolute imports, the plugin provides an easy way to lint out any relative imports that might otherwise have sneaked in.