### PR TITLE
Remove archived flake8-mypy

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ Inspired after reading a [post](https://julien.danjou.info/the-best-flake8-exten
 - [flake8-annotations-complexity](https://github.com/best-doctor/flake8-annotations-complexity) - Plugin to validate annotations complexity.
 - [flake8-annotations-coverage](https://github.com/best-doctor/flake8-annotations-coverage) - Plugin to validate annotations coverage.
 - [flake8-annotations](https://github.com/python-discord/flake8-annotations) - Plugin for flake8 to check for presence of type annotations in function definitions.
-- [flake8-mypy](https://github.com/ambv/flake8-mypy) - Plugin for flake8 integrating Mypy.
 - [flake8-typing-imports](https://github.com/asottile/flake8-typing-imports) - Plugin which checks that typing imports are properly guarded.
 
 


### PR DESCRIPTION
The repo is archived so it shouldn't be included in the listing: https://github.com/ambv/flake8-mypy