### PR TITLE
Remove mutable plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Inspired after reading a [post](https://julien.danjou.info/the-best-flake8-exten
 - [flake8-jira-todo-checker](https://github.com/simonstjg/flake8-jira-todo-checker) - Check that every TODO comment has a valid JIRA issue ID next to it.
 - [flake8-logging-format](https://github.com/globality-corp/flake8-logging-format) - Validate (lack of) logging format strings.
 - [flake8-match](https://github.com/asottile/flake8-match) - Plugin which forbids match statements (PEP 634).
-- [flake8-mutable](https://github.com/ebeweber/flake8-mutable) - Extension for mutable default arguments.
 - [flake8-multiline-containers](https://github.com/jsfehler/flake8-multiline-containers) - Plugin to ensure a consistent format for multiline containers.
 - [flake8-pep3101](https://github.com/gforcada/flake8-pep3101) - Checks for old string formatting.
 - [flake8-pie](https://github.com/sbdchd/flake8-pie) - Extension that implements misc. lints.


### PR DESCRIPTION
`flake8-mutable` has not been updated since 2017 and `bugbear` now includes a check for the same issue:

> B006: Do not use mutable data structures for argument defaults. They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.

See also, this issue: https://github.com/ebeweber/flake8-mutable/issues/27