### PR TITLE
Remove flakehell-online

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Inspired after reading a [post](https://julien.danjou.info/the-best-flake8-exten
 - [Testing](#testing)
 - [Type annotations](#type-annotations)
 
-
 ## Clean code
 
 *Extensions for clean code at your project.*
@@ -100,7 +99,6 @@ Inspired after reading a [post](https://julien.danjou.info/the-best-flake8-exten
 - [flake8-polyfill](https://gitlab.com/pycqa/flake8-polyfill) - A tiny package that provides the poly fill for Flake8 plugins trying to support Flake8 2.x and Flake8 3.x.
 - [flake8-dashboard](https://github.com/aperezhortal/flake8-dashboard) - Plugin to generate an HTML dashboard with reporting the flake8 violations found.
 - [flakehell](https://github.com/flakehell/flakehell) - Wrapper to make it nice, legacy-friendly, and configurable.
-- [flakehell-online](https://github.com/life4/flakehell-online) - Online client-side playground for FlakeHell ([flakehell.orsinium.dev](https://flakehell.orsinium.dev/)).
 - [flake8-codes](https://github.com/orsinium-labs/flake8-codes) - CLI tool to introspect flake8 plugins and their codes.
 
 ## Flake8 frameworks


### PR DESCRIPTION
The playground for flakehell stopped working, so I archived it and shut down the website.
