### PR TITLE
Add `flake8-datetime-import` under "imports" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Extensions for checking import statements.
 - [flake8-import-style](https://github.com/sfstpala/flake8-import-style) - Plugin to ensure explicit module imports.
 - [flake8-tidy-imports](https://github.com/adamchainz/flake8-tidy-imports) - Extension that helps you write tidier imports.
 - [flake8-type-checking](https://github.com/sondrelg/flake8-type-checking) - Plugin for managing type-checking imports & forward references.
+- [flake8-datetime-import](https://github.com/marcgibbons/flake8-datetime-import) - Enforce importing `datetime as dt` and `time as tm`.
 
 ## Testing
 


### PR DESCRIPTION
This plugin enforces importing `datetime as dt` and `time as tm`. Aliasing & namespacing these modules standardizes and removes ambiguity around `datetime` and `time` modules vs. objects.