### PR TITLE
Added [Imports] flake8-internal-name-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Extensions for checking import statements.
 - [flake8-import-style](https://github.com/sfstpala/flake8-import-style) - Plugin to ensure explicit module imports.
 - [flake8-tidy-imports](https://github.com/adamchainz/flake8-tidy-imports) - Extension that helps you write tidier imports.
 - [flake8-type-checking](https://github.com/sondrelg/flake8-type-checking) - Plugin for managing type-checking imports & forward references.
-- [flake8-private-name-import](https://github.com/rows-s/flake8_private_name_import) - Plugin that reports imports of protected and private names.
+- [flake8-internal-name-import](https://github.com/rows-s/flake8_internal_name_import) - Plugin that reports imports of internal names.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Extensions for checking import statements.
 - [flake8-import-style](https://github.com/sfstpala/flake8-import-style) - Plugin to ensure explicit module imports.
 - [flake8-tidy-imports](https://github.com/adamchainz/flake8-tidy-imports) - Extension that helps you write tidier imports.
 - [flake8-type-checking](https://github.com/sondrelg/flake8-type-checking) - Plugin for managing type-checking imports & forward references.
-- [flake8_private_name_import](https://github.com/rows-s/flake8_private_name_import) - Plugin that reports imports of private names.
+- [flake8_private_name_import](https://github.com/rows-s/flake8_private_name_import) - Plugin that reports imports of protected and private names.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Extensions for checking import statements.
 - [flake8-import-style](https://github.com/sfstpala/flake8-import-style) - Plugin to ensure explicit module imports.
 - [flake8-tidy-imports](https://github.com/adamchainz/flake8-tidy-imports) - Extension that helps you write tidier imports.
 - [flake8-type-checking](https://github.com/sondrelg/flake8-type-checking) - Plugin for managing type-checking imports & forward references.
+- [flake8_private_name_import](https://github.com/rows-s/flake8_private_name_import) - Plugin that reports imports of private names.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Extensions for checking import statements.
 - [flake8-import-style](https://github.com/sfstpala/flake8-import-style) - Plugin to ensure explicit module imports.
 - [flake8-tidy-imports](https://github.com/adamchainz/flake8-tidy-imports) - Extension that helps you write tidier imports.
 - [flake8-type-checking](https://github.com/sondrelg/flake8-type-checking) - Plugin for managing type-checking imports & forward references.
-- [flake8-internal-name-import](https://github.com/rows-s/flake8_internal_name_import) - Plugin that reports imports of internal names.
+- [flake8-internal-name-import](https://github.com/rows-s/flake8_internal_name_import) - Plugin that reports imports of protected names.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Extensions for checking import statements.
 - [flake8-import-style](https://github.com/sfstpala/flake8-import-style) - Plugin to ensure explicit module imports.
 - [flake8-tidy-imports](https://github.com/adamchainz/flake8-tidy-imports) - Extension that helps you write tidier imports.
 - [flake8-type-checking](https://github.com/sondrelg/flake8-type-checking) - Plugin for managing type-checking imports & forward references.
-- [flake8_private_name_import](https://github.com/rows-s/flake8_private_name_import) - Plugin that reports imports of protected and private names.
+- [flake8-private-name-import](https://github.com/rows-s/flake8_private_name_import) - Plugin that reports imports of protected and private names.
 
 ## Testing
 


### PR DESCRIPTION
Hope some would find [the plugin](https://github.com/rows-s/flake8_private_name_import) helpful.

Plugin reports imports of internal names, modules and imports from internal modules. Where "internal" is a name or module that starts with "_" but is not dunder (`__future__`, `__all__`, etc.).