### PR TITLE
Update `actions/checkout` to `v4`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   Awesome_Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: npx awesome-lint


### PR DESCRIPTION
These warnings must go away:
https://github.com/DmytroLitvinov/awesome-flake8-extensions/actions/runs/9472717343

<img width="984" alt="Снимок экрана 2024-06-12 в 12 02 35" src="https://github.com/DmytroLitvinov/awesome-flake8-extensions/assets/4660275/befd7693-d7cd-4fec-999d-8665b3576b53">
